### PR TITLE
Enhancement: Enable auto-redirect from root URL to dashboard

### DIFF
--- a/cmd/btfs/daemon.go
+++ b/cmd/btfs/daemon.go
@@ -727,6 +727,7 @@ func serveHTTPApi(req *cmds.Request, cctx *oldcmds.Context) (<-chan error, error
 		corehttp.WebUIOption,
 		corehttp.DashboardOption,
 		corehttp.HostUIOption,
+		corehttp.RootToDashboardOption,
 		gatewayOpt,
 		corehttp.VersionOption(),
 		defaultMux("/debug/vars"),

--- a/core/corehttp/webui.go
+++ b/core/corehttp/webui.go
@@ -15,3 +15,6 @@ var WebUIPaths = []string{
 var HostUIOption = RedirectOption("hostui", WebUIPath)
 var WebUIOption = RedirectOption("webui", WebUIPath)
 var DashboardOption = RedirectOption("dashboard", WebUIPath)
+
+// Allows redirects on root directory (i.e. no option given, for example http://localhost:5001)
+var RootToDashboardOption = RedirectOption("", WebUIPath)


### PR DESCRIPTION
Enables auto-redirect from the root URL (http://127.0.0.1:5001/) to the BTFS dashboard (http://127.0.0.1:5001/btfs/QmW3....GniTT/#/admin/dashboard) , instead of serving a 404 error.

Initially discussed in Discord that this would help newcomers and allow ease of use, where you don't have to remember any dashboard-specific URL to access it.

One thing to note for consideration from the team: This _may_ present a security issue, as anyone browsing to the root URL will be automatically redirected to the dashboard. If you are visiting for the first time, you will have to first configure the API endpoint.