### PR TITLE
Fix: Potential Goroutine Leak Due to Unbuffered Channel in dht.go

### DIFF
--- a/core/coreapi/dht.go
+++ b/core/coreapi/dht.go
@@ -110,7 +110,7 @@ func provideKeys(ctx context.Context, r routing.Routing, cids []cid.Cid) error {
 func provideKeysRec(ctx context.Context, r routing.Routing, bs blockstore.Blockstore, cids []cid.Cid) error {
 	provided := cidutil.NewStreamingSet()
 
-	errCh := make(chan error)
+	errCh := make(chan error,1)
 	go func() {
 		dserv := dag.NewDAGService(blockservice.New(bs, offline.Exchange(bs)))
 		for _, c := range cids {


### PR DESCRIPTION
## Goroutine leak due to unbuffered channel in select with context

### Locations
- [core/coreapi/dht.go:113](https://github.com/bittorrent/go-btfs/blob/master/core/coreapi/dht.go#L113-L135)
### Description
The `provideKeysRec` function may lead to a goroutine leak. The goroutine started within the function sends errors to an un-buffered channel (errCh). If the ctx.Done() case is selected before the goroutine sends an error, the goroutine will block indefinitely, causing a resource leak.
```go
func provideKeysRec(ctx context.Context, r routing.Routing, bs blockstore.Blockstore, cids []cid.Cid) error {
	provided := cidutil.NewStreamingSet()

	errCh := make(chan error)
	go func() {
		dserv := dag.NewDAGService(blockservice.New(bs, offline.Exchange(bs)))
		for _, c := range cids {
			err := dag.Walk(ctx, dag.GetLinksDirect(dserv), c, provided.Visitor(ctx))
			if err != nil {
				errCh <- err
			}
		}
	}()

	for {
		select {
		case k := <-provided.New:
			err := r.Provide(ctx, k, true)
			if err != nil {
				return err
			}
		case err := <-errCh:
			return err
		case <-ctx.Done():
			return ctx.Err()
		}
	}
}
```
### Recommendation
To prevent the potential goroutine leak, consider using a buffered channel to allow the goroutine to send errors without blocking. 
```go
errCh := make(chan error, 1)
```